### PR TITLE
Custom formatting of the tick is now allowed as an option to the default sprintf()

### DIFF
--- a/lib/PDL/Graphics/Prima/Axis.pm
+++ b/lib/PDL/Graphics/Prima/Axis.pm
@@ -26,7 +26,7 @@ PDL::Graphics::Prima::Axis - class for axis handling
          # Labels are optional:
          label => 'Time [s]',
          format_tick => sub {
-            sprintf("%lf", $_)
+            sprintf("%lf", $_[0])
          },
      },
      # Details for y-axis:
@@ -111,6 +111,7 @@ sub profile_default {
 		min => lm::Auto,
 		max => lm::Auto,
 		label => '',
+		format_tick => undef,
 	};
 }
 
@@ -141,6 +142,7 @@ sub init {
 	}
 	# 're'set the label to force the last set of calculations:
 	$self->_label($profile{label});
+	$self->{format_tick} = $profile{format_tick};
 	
 	# Process the minima and maxima.
 	if ($profile{min} == lm::Auto) {
@@ -192,8 +194,8 @@ sub recalculate_edge_requirements {
 	my $largest_width = 0;
 	for (my $i = 0; $i < $Ticks->nelem; $i++) {
 		# Compute its left extent:
-		my $string = defined $axis->format_tick ?
-                        $axis->format_tick($Ticks->at($i)) :
+		my $string = defined $axis->{format_tick} ?
+                        &$axis->{format_tick}->($Ticks->at($i)) :
                         sprintf("%1.8g", $Ticks->at($i));
 		my $points = $canvas->get_text_box($string);
 		$largest_width = $points->[4] if $points->[4] > $largest_width;
@@ -710,8 +712,8 @@ sub draw {
 		# Draw all the tick labels
 		for (my $i = 0; $i < $Ticks->nelem; $i++) {
 			my $x = $Ticks_pixels->at($i);
-			my $string = defined $axis->format_tick ?
-						$axis->format_tick($Ticks->at($i)) :
+			my $string = defined $axis->{format_tick} ?
+						$axis->{format_tick}->($Ticks->at($i)) :
 						sprintf("%1.8g", $Ticks->at($i));
 			
 			# Draw the label:
@@ -763,8 +765,8 @@ sub draw {
 		my $largest_width = 0;
 		for (my $i = 0; $i < $Ticks->nelem; $i++) {
 			my $y = $Ticks_pixels->at($i);
-			my $string = defined $axis->format_tick ?
-						$axis->format_tick($Ticks->at($i)) :
+			my $string = defined $axis->{format_tick} ?
+						&$axis->{format_tick}->($Ticks->at($i)) :
 						sprintf("%1.8g", $Ticks->at($i));
 			
 			# Draw the label:


### PR DESCRIPTION
Allowing for custom format of ticks that get drawn on the plot.
Useful for cases in plots where the data is a time series and the user wants to view the tick in
HH:MM format rather than time since epoch which is how the data might be stored
in a PDL object.
