### PR TITLE
Perldl win32 term

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -13,7 +13,7 @@ WriteMakefile(
   PREREQ_PM => {
     'PDL::Drawing::Prima' => '0.15',
     'PDL' => '2.4.0',
-    Prima => '1.67',
+    Prima => '1.68',
   },
   TEST_REQUIRES => {
     'Test::More' => '0.88',

--- a/lib/PDL/Demos/Prima.pm
+++ b/lib/PDL/Demos/Prima.pm
@@ -125,20 +125,15 @@ sub setup_gui {
 
 																	# Window
 	$gui->{window} = Prima::Window->create(
-		place => {
-			relx => 0.15, relwidth => 0.7, relheight => 0.7, rely => 0.15,
+		place     => {
+			relx   => 0.15, relwidth => 0.7, relheight => 0.7, rely => 0.15,
 			anchor => 'sw',
 		},
-		sizeMax => [600, 800],
-		sizeMin => [600, 800],
-		text => 'PDL::Graphics::Prima Demo',
-		onDestroy => sub {
-			require Prima::Utils;
-			# Throw an exception after destruction is complete so that we
-			# break out of the $::application->go loop.
-			Prima::Utils::post(sub { die 'time to exit the event loop' });
-		},
-		onKeyUp => \&keypress_handler,
+		sizeMax   => [600, 800],
+		sizeMin   => [600, 800],
+		text      => 'PDL::Graphics::Prima Demo',
+		onDestroy => sub { $::application->stop },
+		onKeyUp   => \&keypress_handler,
 	);
 	$gui->{window}->font->size(12);
 																		# Title


### PR DESCRIPTION
win32: Prima v1.68 supports File.onRead on console input, which together with the new Prima::sys::win32::ReadConsoleInput makes it possible to write a more-or-less proper emulation of non-blocking STDIN on windows.

How to check:

1. perldl
2. use PDL::Graphics::Prima::Simple
3. line_plot(sequence(10))

see that the graph windows and the input line are both responsible