### PR TITLE
Documentation: Add some links

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,3 +1,5 @@
+- doc improvements (#54) - thanks @HaraldJoerg
+
 0.21 2024-04-22
 - demo now only loads Prima when run, reducing perldl problems
 

--- a/lib/PDL/Graphics/Prima/PlotType.pm
+++ b/lib/PDL/Graphics/Prima/PlotType.pm
@@ -1626,7 +1626,8 @@ you should use pimage::Basic instead.
 The x- and y-bounds of your Grid are taken from the dataset x- and y-bounds,
 so look into L<PDL::Graphics::Prima::DataSet> for details.
 
-working here - expand, give an example
+The F<examples> directory in this distribution demonstrates the usage,
+e.g. in F<examples/intensity-plot.pl>.
 
 =cut
 

--- a/lib/PDL/Graphics/Prima/Simple.pm
+++ b/lib/PDL/Graphics/Prima/Simple.pm
@@ -162,7 +162,7 @@ is used.
 
 Both L</matrix_plot> and L</imag_plot> take one or
 three arguments, the first two of which specify the x-bounds and the
-y-bounds, the third (or only) of which is the matrix to plot
+y-bounds, the third (or only) of which is the 2D ndarray to plot.
 
 =item plot (...)
 
@@ -1053,11 +1053,14 @@ and its equivalent L<plot|/"PLOT FUNCTION"> commands are:
      plotType => pgrid::Matrix,
  ));
 
+See L<PDL::Graphics::Prima::PlotType/pgrid::Matrix> for how to specify
+the colors, and F<examples/intensity-plot.pl> for a complete example.
+
 Specifying edges looks like this:
 
  matrix_plot ([0 => 5], [1 => 10], $matrix);
 
-and the quivalent is:
+and the equivalent is:
 
  plot(-image => ds::Grid(
      $matrix,


### PR DESCRIPTION
In PGP::Simple, point to the description of pgrid::Matrix. Also point to the examples directory which has ready-to-run examples.